### PR TITLE
Fix installation of version 2.2.2

### DIFF
--- a/Formula/xchtmlreport@2.2.2.rb
+++ b/Formula/xchtmlreport@2.2.2.rb
@@ -1,4 +1,4 @@
-class Xchtmlreport222 < Formula
+class XchtmlreportAT222 < Formula
   desc "XCTestHTMLReport: Xcode-like HTML report for Unit and UI Tests"
   homepage "https://github.com/XCTestHTMLReport/XCTestHTMLReport"
   url "https://github.com/XCTestHTMLReport/XCTestHTMLReport/archive/refs/tags/2.2.2.tar.gz"

--- a/Formula/xchtmlreport@2.2.2.rb
+++ b/Formula/xchtmlreport@2.2.2.rb
@@ -1,4 +1,4 @@
-class Xchtmlreport < Formula
+class Xchtmlreport222 < Formula
   desc "XCTestHTMLReport: Xcode-like HTML report for Unit and UI Tests"
   homepage "https://github.com/XCTestHTMLReport/XCTestHTMLReport"
   url "https://github.com/XCTestHTMLReport/XCTestHTMLReport/archive/refs/tags/2.2.2.tar.gz"


### PR DESCRIPTION
Fixed the incorrect formula class name which prevents `brew install XCTestHtmlReport/xchtmlreport/xchtmlreport`